### PR TITLE
Fix a broken path extension and add TestBase class to integration test

### DIFF
--- a/System.IO.Abstractions.SMB.Tests.Integration/IntegrationTestSettings.cs
+++ b/System.IO.Abstractions.SMB.Tests.Integration/IntegrationTestSettings.cs
@@ -7,7 +7,7 @@ namespace System.IO.Abstractions.SMB.Tests.Integration
 {
     public class IntegrationTestSettings
     {
-        public ShareCredentials ShareCredentials {get; set;}
+        public ShareCredentials ShareCredentials { get; set; }
 
         public List<Share> Shares { get; set; }
     }
@@ -21,12 +21,30 @@ namespace System.IO.Abstractions.SMB.Tests.Integration
 
     public class Share
     {
-        public string RootUncPath { get; set; }
-        public string RootSmbUri { get; set; }
+        public string HostName { get; set; }
+        public string ShareName { get; set; }
+
+        public string RootUncPath
+        {
+            get
+            {
+                var s = Path.DirectorySeparatorChar;
+                return $"{s}{s}{HostName}{s}{ShareName}";
+            }
+        }
+
+        public string RootSmbUri
+        {
+            get
+            {
+                return $@"smb://{HostName}/{ShareName}";
+            }
+        }
 
         public List<string> Files { get; set; }
         public List<string> Directories { get; set; }
     }
+
     public static class IntegrationTestSettingsExtensions
     {
         public static void Initialize(this IntegrationTestSettings settings)

--- a/System.IO.Abstractions.SMB.Tests.Integration/TestBase.cs
+++ b/System.IO.Abstractions.SMB.Tests.Integration/TestBase.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.IO.Abstractions.SMB.Tests.Integration
+{
+    public class TestBase : IDisposable
+    {
+        private IntegrationTestSettings _settings = new IntegrationTestSettings();
+
+        private readonly ISMBClientFactory _clientFactory;
+
+        public TestBase()
+        {
+            _settings.Initialize();
+            SMBCredentialProvider = new SMBCredentialProvider();
+            _clientFactory = new SMB2ClientFactory();
+            FileSystem = new SMBFileSystem(_clientFactory, SMBCredentialProvider);
+        }
+
+        public IntegrationTestSettings TestSettings
+        {
+            get
+            {
+                return _settings;
+            }
+        }
+
+        public IFileSystem FileSystem { get; }
+
+        public ISMBCredentialProvider SMBCredentialProvider { get; }
+
+        public virtual void Dispose()
+        {
+
+        }
+    }
+}

--- a/System.IO.Abstractions.SMB.Tests.Integration/testsettings.json
+++ b/System.IO.Abstractions.SMB.Tests.Integration/testsettings.json
@@ -7,8 +7,8 @@
     },
     "Shares": [
       {
-        "RootUncPath": "\\\\host\\share",
-        "RootSmbUri": "smb://host/share",
+        "HostName": "",
+        "ShareName": "",
         "Files": [
           "file.txt"
         ],

--- a/System.IO.Abstractions.SMB.Tests/Path/PathExtensionsTests.cs
+++ b/System.IO.Abstractions.SMB.Tests/Path/PathExtensionsTests.cs
@@ -112,7 +112,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
             foreach (var property in _smbUriTestData.GetType().GetProperties())
             {
                 var path = (string)property.GetValue(_smbUriTestData);
-                var relative = ReplacePathSeperators(path.Replace(_smbUriTestData.Root, ""), @"\");
+                var relative = RemoveLeadingSeperator(ReplacePathSeperators(path.Replace(_smbUriTestData.Root, ""), @"\"));
                 var relativeSharePath = path.RelativeSharePath();
 
                 Assert.Equal(relative, relativeSharePath);
@@ -139,6 +139,21 @@ namespace System.IO.Abstractions.SMB.Tests.Path
             foreach (var pathSeperator in pathSeperators)
             {
                 input = input.Replace(pathSeperator, newValue);
+            }
+
+            return input;
+        }
+
+        private string RemoveLeadingSeperator(string input)
+        {
+            string[] pathSeperators = { @"\", @"/" };
+
+            foreach (var pathSeperator in pathSeperators)
+            {
+                if (input.StartsWith(pathSeperator))
+                {
+                    input = input.Remove(0, 1);
+                }
             }
 
             return input;

--- a/System.IO.Abstractions.SMB2/PathExtensions.cs
+++ b/System.IO.Abstractions.SMB2/PathExtensions.cs
@@ -51,9 +51,7 @@ namespace System.IO.Abstractions.SMB
 
         public static string RelativeSharePath(this string path)
         {
-            var sharePath = path.SharePath();
-
-            var relativePath = path.Replace(sharePath, "", StringComparison.InvariantCultureIgnoreCase).Replace("/", @"\");
+            var relativePath = path.RemoveShareNameFromPath().RemoveLeadingSeperators().Replace("/", @"\");
 
             return relativePath;
         }
@@ -63,6 +61,28 @@ namespace System.IO.Abstractions.SMB
             foreach (var pathSeperator in pathSeperators)
             {
                 input = input.Replace(pathSeperator, "");
+            }
+
+            return input;
+        }
+
+        private static string RemoveShareNameFromPath(this string input)
+        {
+            var sharePath = input.SharePath();
+
+            input = input.Replace(sharePath, "", StringComparison.InvariantCultureIgnoreCase);
+
+            return input;
+        }
+
+        private static string RemoveLeadingSeperators(this string input)
+        {
+            foreach (var pathSeperator in pathSeperators)
+            {
+                if(input.StartsWith(pathSeperator))
+                {
+                    input = input.Remove(0,1);
+                }
             }
 
             return input;


### PR DESCRIPTION
Remove leading slash for the `RealtiveSharePath`

New `testsettings.json` structure to accomodate `IntegrationTestSettings` changes