### PR TITLE
Implement SMBDriveInfo and SMBDriveInfoFactory

### DIFF
--- a/System.IO.Abstractions.SMB.Tests.Integration/DirectoryTests.cs
+++ b/System.IO.Abstractions.SMB.Tests.Integration/DirectoryTests.cs
@@ -20,6 +20,7 @@ namespace System.IO.Abstractions.SMB.Tests.Integration
         }
 
         [Fact]
+        [Trait("Category", "Integration")]
         public void CanCreateDirectoryInUncRootDirectory()
         {
             var testCredentials = TestSettings.ShareCredentials;
@@ -36,6 +37,7 @@ namespace System.IO.Abstractions.SMB.Tests.Integration
         }
 
         [Fact]
+        [Trait("Category", "Integration")]
         public void CanEnumerateFilesUncRootDirectory()
         {
             var testCredentials = TestSettings.ShareCredentials;
@@ -50,6 +52,7 @@ namespace System.IO.Abstractions.SMB.Tests.Integration
         }
 
         [Fact]
+        [Trait("Category", "Integration")]
         public void CanEnumerateFilesSmbRootDirectory()
         {
             var testCredentials = TestSettings.ShareCredentials;

--- a/System.IO.Abstractions.SMB.Tests.Integration/DriveInfoTests.cs
+++ b/System.IO.Abstractions.SMB.Tests.Integration/DriveInfoTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace System.IO.Abstractions.SMB.Tests.Integration
+{
+    public class DriveInfoTests : TestBase
+    {
+        private IFileSystem _fileSystem;
+        private ISMBCredentialProvider _smbCredentialProvider;
+        private ISMBClientFactory _smbClientFactory;
+
+        public DriveInfoTests(): base()
+        {
+            _smbCredentialProvider = new SMBCredentialProvider();
+            _smbClientFactory = new SMB2ClientFactory();
+            _fileSystem = new SMBFileSystem(_smbClientFactory, _smbCredentialProvider);
+        }
+
+        public override void Dispose()
+        {
+
+        }
+
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void FromDriveName_ReturnsNotNull_ForSmbUri()
+        {
+            var credentials = TestSettings.ShareCredentials;
+            var share = TestSettings.Shares.FirstOrDefault();
+
+            _smbCredentialProvider.AddSMBCredential(new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, share.RootSmbUri));
+
+            var smbDriveInfoFactory = new SMBDriveInfoFactory(_fileSystem, _smbCredentialProvider, _smbClientFactory);
+
+            var shareInfo = smbDriveInfoFactory.FromDriveName(share.ShareName);
+
+            Assert.NotNull(shareInfo);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void FromDriveName_ReturnsNotNull_ForUncPath()
+        {
+            var credentials = TestSettings.ShareCredentials;
+            var share = TestSettings.Shares.FirstOrDefault();
+
+            _smbCredentialProvider.AddSMBCredential(new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, share.RootUncPath));
+
+            var smbDriveInfoFactory = new SMBDriveInfoFactory(_fileSystem, _smbCredentialProvider, _smbClientFactory);
+
+            var shareInfo = smbDriveInfoFactory.FromDriveName(share.ShareName);
+
+            Assert.NotNull(shareInfo);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void GetDrives_ReturnsNotNull_ForSmbUri()
+        {
+            var credentials = TestSettings.ShareCredentials;
+            var share = TestSettings.Shares.FirstOrDefault();
+
+            _smbCredentialProvider.AddSMBCredential(new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, share.RootSmbUri));
+
+            var smbDriveInfoFactory = new SMBDriveInfoFactory(_fileSystem, _smbCredentialProvider, _smbClientFactory);
+
+            var shares = smbDriveInfoFactory.GetDrives();
+
+            Assert.NotNull(shares);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void GetDrives_ReturnsNotNull_ForUncPath()
+        {
+            var credentials = TestSettings.ShareCredentials;
+            var share = TestSettings.Shares.FirstOrDefault();
+
+            _smbCredentialProvider.AddSMBCredential(new SMBCredential(credentials.Domain, credentials.Username, credentials.Password, share.RootUncPath));
+
+            var smbDriveInfoFactory = new SMBDriveInfoFactory(_fileSystem, _smbCredentialProvider, _smbClientFactory);
+            
+            var shares = smbDriveInfoFactory.GetDrives();
+
+            Assert.NotNull(shares);
+        }
+
+
+    }
+}

--- a/System.IO.Abstractions.SMB.Tests/Path/PathExtensionsTests.cs
+++ b/System.IO.Abstractions.SMB.Tests/Path/PathExtensionsTests.cs
@@ -7,6 +7,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
     {
         private readonly IPathTestData _smbUriTestData;
         private readonly IPathTestData _uncPathTestData;
+        private readonly char s = IO.Path.DirectorySeparatorChar;
 
         public PathExtensionsTests()
         {
@@ -15,7 +16,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void IsSmbReturnsTrueForSmbUrl()
+        public void IsSmb_ReturnsTrue_ForSmbUrl()
         {
             foreach (var property in _smbUriTestData.GetType().GetProperties())
             {
@@ -26,7 +27,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void IsSmbReturnsTrueForUncPath()
+        public void IsSmb_ReturnsTrue_ForUncPath()
         {
             foreach (var property in _uncPathTestData.GetType().GetProperties())
             {
@@ -37,7 +38,39 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void GetHostNameReturnsHostForSmbUrl()
+        public void BuildSharePath_ReturnsSmbPath_ForSmbPath()
+        {
+            foreach (var property in _smbUriTestData.GetType().GetProperties())
+            {
+                var path = (string)property.GetValue(_smbUriTestData);
+                var testBuildShareName = "TestBuildSharePath";
+
+                var builtSharePath = path.BuildSharePath(testBuildShareName);
+
+                string expectedPath = $"smb://{path.HostName()}/{testBuildShareName}";
+
+                Assert.Equal(expectedPath, builtSharePath);
+            }
+        }
+
+        [Fact]
+        public void BuildSharePath_ReturnsSmbPath_ForUncPath()
+        {
+            foreach (var property in _uncPathTestData.GetType().GetProperties())
+            {
+                var path = (string)property.GetValue(_uncPathTestData);
+                var testBuildShareName = "TestBuildSharePath";
+
+                var builtSharePath = path.BuildSharePath(testBuildShareName);
+
+                string expectedPath = $"{s}{s}{path.HostName()}{s}{testBuildShareName}";
+                
+                Assert.Equal(expectedPath, builtSharePath);
+            }
+        }
+
+        [Fact]
+        public void HostName_ReturnsHost_ForSmbUrl()
         {
             foreach (var property in _smbUriTestData.GetType().GetProperties())
             {
@@ -49,7 +82,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void GetHostNameReturnsHostForUncPath()
+        public void HostName_ReturnsHost_ForUncPath()
         {
             foreach (var property in _uncPathTestData.GetType().GetProperties())
             {
@@ -61,7 +94,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void GetSharePathReturnsSharePathForSmbUri()
+        public void SharePath_ReturnsSharePath_ForSmbUri()
         {
             foreach (var property in _smbUriTestData.GetType().GetProperties())
             {
@@ -72,7 +105,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void GetSharePathReturnsSharePathForUncPath()
+        public void SharePath_ReturnsSharePath_ForUncPath()
         {
             foreach (var property in _uncPathTestData.GetType().GetProperties())
             {
@@ -83,7 +116,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void GetShareNameReturnsShareForSmbUri()
+        public void ShareName_ReturnsShare_ForSmbUri()
         {
             foreach (var property in _smbUriTestData.GetType().GetProperties())
             {
@@ -95,7 +128,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void GetShareNameReturnsShareForUncPath()
+        public void ShareName_ReturnsShare_ForUncPath()
         {
             foreach (var property in _uncPathTestData.GetType().GetProperties())
             {
@@ -107,7 +140,7 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void GetRelativeSharePathReturnsPathAfterShareRootForSmbUri()
+        public void RelativeSharePath_ReturnsPathAfterShareRoot_ForSmbUri()
         {
             foreach (var property in _smbUriTestData.GetType().GetProperties())
             {
@@ -120,12 +153,12 @@ namespace System.IO.Abstractions.SMB.Tests.Path
         }
 
         [Fact]
-        public void GetRelativeSharePathReturnsPathAfterShareRootForUncPath()
+        public void RelativeSharePath_ReturnsPathAfterShareRoot_ForUncPath()
         {
             foreach (var property in _uncPathTestData.GetType().GetProperties())
             {
                 var path = (string)property.GetValue(_uncPathTestData);
-                var relative = ReplacePathSeperators(path.Replace(_uncPathTestData.Root, ""), @"\");
+                var relative = RemoveLeadingSeperator(ReplacePathSeperators(path.Replace(_uncPathTestData.Root, ""), @"\"));
                 var relativeSharePath = path.RelativeSharePath();
 
                 Assert.Equal(relative, relativeSharePath);

--- a/System.IO.Abstractions.SMB2/ISMBCredentialProvider.cs
+++ b/System.IO.Abstractions.SMB2/ISMBCredentialProvider.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+
 namespace System.IO.Abstractions.SMB
 {
     public interface ISMBCredentialProvider
     {
         ISMBCredential GetSMBCredential(string path);
+        IEnumerable<ISMBCredential> GetSMBCredentials();
         void AddSMBCredential(ISMBCredential credential);
     }
 }

--- a/System.IO.Abstractions.SMB2/PathExtensions.cs
+++ b/System.IO.Abstractions.SMB2/PathExtensions.cs
@@ -7,6 +7,7 @@ namespace System.IO.Abstractions.SMB
     public static class PathExtensions
     {
         static readonly string[] pathSeperators = { @"\", "/" };
+        static readonly char s = IO.Path.DirectorySeparatorChar;
 
         public static bool IsValidSharePath(this string path)
         {
@@ -20,6 +21,20 @@ namespace System.IO.Abstractions.SMB
         {
             var uri = new Uri(path);
             return uri.Scheme.Equals("smb") || uri.IsUnc;
+        }
+
+
+        public static string BuildSharePath(this string path, string shareName)
+        {
+            var uri = new Uri(path);
+            if(!uri.IsUnc)
+            {
+                return $"smb://{path.HostName()}/{shareName}";
+            }
+            else
+            {
+                return $"{s}{s}{path.HostName()}{s}{shareName}";
+            }
         }
 
         public static string HostName(this string path)
@@ -44,7 +59,7 @@ namespace System.IO.Abstractions.SMB
             if (uri.Scheme.Equals("smb"))
                 sharePath = $"{uri.Scheme}://{uri.Host}/{uri.Segments[1].RemoveAnySeperators()}";
             else if (uri.IsUnc)
-                sharePath = $@"\\{uri.Host}\{uri.Segments[1].RemoveAnySeperators()}";
+                sharePath = $@"{s}{s}{uri.Host}{s}{uri.Segments[1].RemoveAnySeperators()}";
 
             return sharePath;
         }

--- a/System.IO.Abstractions.SMB2/SMBCredentialProvider.cs
+++ b/System.IO.Abstractions.SMB2/SMBCredentialProvider.cs
@@ -25,10 +25,17 @@ namespace System.IO.Abstractions.SMB
             }
         }
 
+        public IEnumerable<ISMBCredential> GetSMBCredentials()
+        {
+            return credentials;
+        }
+
         public void AddSMBCredential(ISMBCredential credential)
         {
             credential.SetParentList(credentials);
             credentials.Add(credential);
         }
+
+        
     }
 }

--- a/System.IO.Abstractions.SMB2/SMBDirectoryInfo.cs
+++ b/System.IO.Abstractions.SMB2/SMBDirectoryInfo.cs
@@ -46,7 +46,7 @@ namespace System.IO.Abstractions.SMB
             }
             Parent = _smbDirectory.GetParent(fileName, credential);
             var pathRoot = Path.GetPathRoot(fileName);
-            if (pathRoot != string.Empty)
+            if (pathRoot != string.Empty && Parent != null)
             {
                 Root = _directoryInfoFactory.FromDirectoryName(pathRoot, credential);
             }

--- a/System.IO.Abstractions.SMB2/SMBDirectoryInfoFactory.cs
+++ b/System.IO.Abstractions.SMB2/SMBDirectoryInfoFactory.cs
@@ -61,8 +61,14 @@ namespace System.IO.Abstractions.SMB
 
             ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
 
+            if (status != NTStatus.STATUS_SUCCESS)
+            {
+                return null;
+            }
+
             status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
                     CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
+
             if (status != NTStatus.STATUS_SUCCESS)
             {
                 return null;

--- a/System.IO.Abstractions.SMB2/SMBDriveInfo.cs
+++ b/System.IO.Abstractions.SMB2/SMBDriveInfo.cs
@@ -1,31 +1,37 @@
-﻿using System;
+﻿using SmbLibraryStd;
+using System;
 namespace System.IO.Abstractions.SMB
 {
     public class SMBDriveInfo : IDriveInfo
     {
-        public SMBDriveInfo(IFileSystem fileSystem)
+        private readonly SMBFileSystemInformation _smbFileSystemInformation;
+        private SMBDirectoryInfoFactory _dirInfoFactory => FileSystem.DirectoryInfo as SMBDirectoryInfoFactory;
+        public SMBDriveInfo(string path, IFileSystem fileSystem, SMBFileSystemInformation smbFileSystemInformation, ISMBCredential credential)
         {
             FileSystem = fileSystem;
+            _smbFileSystemInformation = smbFileSystemInformation;
+            Name = path.ShareName();
+            RootDirectory = _dirInfoFactory.FromDirectoryName(path, credential);
         }
 
         public IFileSystem FileSystem { get; }
 
-        public long AvailableFreeSpace => throw new NotImplementedException();
+        public long AvailableFreeSpace => _smbFileSystemInformation.SizeInformation.CallerAvailableAllocationUnits;
 
-        public string DriveFormat => throw new NotImplementedException();
+        public string DriveFormat => _smbFileSystemInformation.AttributeInformation.FileSystemName;
 
-        public DriveType DriveType => throw new NotImplementedException();
+        public DriveType DriveType => DriveType.Network;
 
         public bool IsReady => throw new NotImplementedException();
 
-        public string Name => throw new NotImplementedException();
+        public string Name { get; }
 
-        public IDirectoryInfo RootDirectory => throw new NotImplementedException();
+        public IDirectoryInfo RootDirectory { get; }
 
-        public long TotalFreeSpace => throw new NotImplementedException();
+        public long TotalFreeSpace => _smbFileSystemInformation.SizeInformation.ActualAvailableAllocationUnits;
 
-        public long TotalSize => throw new NotImplementedException();
+        public long TotalSize => _smbFileSystemInformation.SizeInformation.TotalAllocationUnits;
 
-        public string VolumeLabel { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string VolumeLabel { get => _smbFileSystemInformation.VolumeInformation.VolumeLabel; set => throw new NotSupportedException(); }
     }
 }

--- a/System.IO.Abstractions.SMB2/SMBFileSystem.cs
+++ b/System.IO.Abstractions.SMB2/SMBFileSystem.cs
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.SMB
             FileInfo = new SMBFileInfoFactory(this, credentialProvider, ismbClientfactory);
             FileStream = new SMBFileStreamFactory(this);
             Path = new PathWrapper(this);
-            DriveInfo = new SMBDriveInfoFactory();
+            DriveInfo = new SMBDriveInfoFactory(this,credentialProvider, ismbClientfactory);
         }
 
         public IDirectory Directory { get; }

--- a/System.IO.Abstractions.SMB2/SMBFileSystemInformation.cs
+++ b/System.IO.Abstractions.SMB2/SMBFileSystemInformation.cs
@@ -1,0 +1,47 @@
+﻿using SmbLibraryStd;
+using SmbLibraryStd.Client;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.IO.Abstractions.SMB
+{
+    public class SMBFileSystemInformation
+    {
+        public FileFsVolumeInformation VolumeInformation { get; }
+        public FileFsDeviceInformation DeviceInformation { get; }
+        public FileFsFullSizeInformation SizeInformation { get; }
+        public FileFsAttributeInformation AttributeInformation { get; }
+        public FileFsControlInformation ControlInformation { get; }
+        public FileFsSectorSizeInformation SectorSizeInformation { get; }
+
+        public SMBFileSystemInformation(ISMBFileStore fileStore, string path)
+        {
+            var shareName = path.ShareName();
+            var relativePath = path.RelativeSharePath();
+
+            NTStatus status = NTStatus.STATUS_SUCCESS;
+
+            status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath,
+                                      AccessMask.GENERIC_READ, 0, ShareAccess.Read, CreateDisposition.FILE_OPEN,
+                                      CreateOptions.FILE_DIRECTORY_FILE, null);
+
+            if (status == NTStatus.STATUS_SUCCESS)
+            {
+                fileStore.GetFileSystemInformation(out var fileFsVolumeInformation, FileSystemInformationClass.FileFsVolumeInformation);
+                fileStore.GetFileSystemInformation(out var fileFsDeviceInformation, FileSystemInformationClass.FileFsDeviceInformation);
+                fileStore.GetFileSystemInformation(out var fileFsFullSizeInformation, FileSystemInformationClass.FileFsFullSizeInformation);
+                fileStore.GetFileSystemInformation(out var fileFsAttributeInformation, FileSystemInformationClass.FileFsAttributeInformation);
+                fileStore.GetFileSystemInformation(out var fileFsControlInformation, FileSystemInformationClass.FileFsControlInformation);
+                fileStore.GetFileSystemInformation(out var fileFsSectorSizeInformation, FileSystemInformationClass.FileFsSectorSizeInformation);
+
+                VolumeInformation = (FileFsVolumeInformation)fileFsVolumeInformation;
+                DeviceInformation = (FileFsDeviceInformation)fileFsDeviceInformation;
+                SizeInformation = (FileFsFullSizeInformation)fileFsFullSizeInformation;
+                AttributeInformation = (FileFsAttributeInformation)fileFsAttributeInformation;
+                ControlInformation = (FileFsControlInformation)fileFsControlInformation;
+                SectorSizeInformation = (FileFsSectorSizeInformation)fileFsSectorSizeInformation;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Format test method names so they are more readable. 
- Add DriveInfo integration tests.
- Add GetSmbCredentials so that we can return SMBDriveInfo for all shares we have credentials for.
- Add BuildSharePath PathExtension to consolidate building a smb uri or unc path.
- Add check for null Parent in SMBDirectoryInfo to prevent an infinite loop for trying to retrive Root FromDirectoryName.
- Add NTStatus check in DirectoryInfoFactory to exit when we fail to connect to the share.
- Implement SMBDriveInfo properties.
- Implement SMBDriveInfoFactory.
- Add Parameters to SMBDriveInfoFactory in SMBFileSystem.
- Create SMBFileSystemInformation to easily retrieve all FileSystemInformationClass.