### PR TITLE
Add Source Link and Build Symbol Package to SmbAbstraction project

### DIFF
--- a/SmbAbstraction/SmbAbstraction.csproj
+++ b/SmbAbstraction/SmbAbstraction.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -7,6 +7,10 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Description>This library implements the System.IO.Abstractions interfaces for interacting with the filesystem, and adds support for interacting with UNC or SMB paths.</Description>
     <PackageId>SmbAbstraction</PackageId>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageVersion>1.0.3</PackageVersion>
   </PropertyGroup>
 
@@ -18,10 +22,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Abstractions" Version="7.0.15" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.3">
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SMBLibraryLite" Version="1.3.10" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add Source Link and Build Symbol Package to SmbAbstraction project

NuGet.Build.Packaging targeting Version 0.2.2 because I couldn't pull 0.2.3