### PR TITLE
Add Logging and wrap exceptions with SmbException 

### DIFF
--- a/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/Directory/DirectoryTests.Variations.cs
@@ -3,21 +3,22 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.Directory
 {
     public class UncPathTests : DirectoryTests, IClassFixture<UncPathFixture>
     {
-        public UncPathTests(UncPathFixture fixture) : base(fixture) { }
+        public UncPathTests(UncPathFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class SmbUriTests : DirectoryTests, IClassFixture<SmbUriFixture>
     {
-        public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
+        public SmbUriTests(SmbUriFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class BaseFileSystemTests : DirectoryTests, IClassFixture<BaseFileSystemFixture>
     {
-        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+        public BaseFileSystemTests(BaseFileSystemFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 }

--- a/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.Variations.cs
@@ -3,21 +3,22 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.DirectoryInfo
 {
     public class UncPathTests: DirectoryInfoTests, IClassFixture<UncPathFixture>
     {
-        public UncPathTests(UncPathFixture fixture) : base(fixture) { }
+        public UncPathTests(UncPathFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class SmbUriTests : DirectoryInfoTests, IClassFixture<SmbUriFixture>
     {
-        public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
+        public SmbUriTests(SmbUriFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class BaseFileSystemTests : DirectoryInfoTests, IClassFixture<BaseFileSystemFixture>
     {
-        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+        public BaseFileSystemTests(BaseFileSystemFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 }

--- a/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/DirectoryInfo/DirectoryInfoTests.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.DirectoryInfo
 {
@@ -12,9 +13,9 @@ namespace SmbAbstraction.Tests.Integration.DirectoryInfo
         readonly TestFixture _fixture;
         readonly IFileSystem _fileSystem;
 
-        public DirectoryInfoTests(TestFixture fixture)
+        public DirectoryInfoTests(TestFixture fixture, ITestOutputHelper outputHelper)
         {
-            _fixture = fixture;
+            _fixture = fixture.WithLoggerFactory(outputHelper.ToLoggerFactory());
             _fileSystem = _fixture.FileSystem;
         }
 

--- a/SmbAbstraction.Tests.Integration/DriveInfo/DriveInfoTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/DriveInfo/DriveInfoTests.Variations.cs
@@ -3,21 +3,22 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.DriveInfo
 {
     public class UncPathTests : DriveInfoTests, IClassFixture<UncPathFixture>
     {
-        public UncPathTests(UncPathFixture fixture) : base(fixture) { }
+        public UncPathTests(UncPathFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class SmbUriTests : DriveInfoTests, IClassFixture<SmbUriFixture>
     {
-        public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
+        public SmbUriTests(SmbUriFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class BaseFileSystemTests : DriveInfoTests, IClassFixture<BaseFileSystemFixture>
     {
-        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+        public BaseFileSystemTests(BaseFileSystemFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 }

--- a/SmbAbstraction.Tests.Integration/DriveInfo/DriveInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/DriveInfo/DriveInfoTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO.Abstractions;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.DriveInfo
 {
@@ -9,9 +10,9 @@ namespace SmbAbstraction.Tests.Integration.DriveInfo
         readonly TestFixture _fixture;
         private IFileSystem _fileSystem;
 
-        public DriveInfoTests(TestFixture fixture)
+        public DriveInfoTests(TestFixture fixture, ITestOutputHelper outputHelper)
         {
-            _fixture = fixture;
+            _fixture = fixture.WithLoggerFactory(outputHelper.ToLoggerFactory());
             _fileSystem = _fixture.FileSystem;
         }
 

--- a/SmbAbstraction.Tests.Integration/File/FileTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/File/FileTests.Variations.cs
@@ -3,21 +3,22 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.File
 {
     public class UncPathTests : FileTests, IClassFixture<UncPathFixture>
     {
-        public UncPathTests(UncPathFixture fixture) : base(fixture) { }
+        public UncPathTests(UncPathFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class SmbUriTests : FileTests, IClassFixture<SmbUriFixture>
     {
-        public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
+        public SmbUriTests(SmbUriFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class BaseFileSystemTests : FileTests, IClassFixture<BaseFileSystemFixture>
     {
-        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+        public BaseFileSystemTests(BaseFileSystemFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 }

--- a/SmbAbstraction.Tests.Integration/File/FileTests.cs
+++ b/SmbAbstraction.Tests.Integration/File/FileTests.cs
@@ -5,6 +5,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.File
 {
@@ -13,9 +14,9 @@ namespace SmbAbstraction.Tests.Integration.File
         readonly TestFixture _fixture;
         private IFileSystem _fileSystem;
 
-        public FileTests(TestFixture fixture)
+        public FileTests(TestFixture fixture, ITestOutputHelper outputHelper)
         {
-            _fixture = fixture;
+            _fixture = fixture.WithLoggerFactory(outputHelper.ToLoggerFactory());
             _fileSystem = _fixture.FileSystem;
         }
 

--- a/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.Variations.cs
+++ b/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.Variations.cs
@@ -3,21 +3,22 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.FileInfo
 {
     public class UncPathTests : FileInfoTests, IClassFixture<UncPathFixture>
     {
-        public UncPathTests(UncPathFixture fixture) : base(fixture) { }
+        public UncPathTests(UncPathFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class SmbUriTests : FileInfoTests, IClassFixture<SmbUriFixture>
     {
-        public SmbUriTests(SmbUriFixture fixture) : base(fixture) { }
+        public SmbUriTests(SmbUriFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 
     public class BaseFileSystemTests : FileInfoTests, IClassFixture<BaseFileSystemFixture>
     {
-        public BaseFileSystemTests(BaseFileSystemFixture fixture) : base(fixture) { }
+        public BaseFileSystemTests(BaseFileSystemFixture fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     }
 }

--- a/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.cs
+++ b/SmbAbstraction.Tests.Integration/FileInfo/FileInfoTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SmbAbstraction.Tests.Integration.FileInfo
 {
@@ -11,9 +12,9 @@ namespace SmbAbstraction.Tests.Integration.FileInfo
         readonly TestFixture _fixture;
         readonly IFileSystem _fileSystem;
 
-        public FileInfoTests(TestFixture fixture)
+        public FileInfoTests(TestFixture fixture, ITestOutputHelper outputHelper)
         {
-            _fixture = fixture;
+            _fixture = fixture.WithLoggerFactory(outputHelper.ToLoggerFactory());
             _fileSystem = _fixture.FileSystem;
         }
 

--- a/SmbAbstraction.Tests.Integration/Fixtures/TestFixture.cs
+++ b/SmbAbstraction.Tests.Integration/Fixtures/TestFixture.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Runtime.InteropServices;
@@ -14,7 +15,13 @@ namespace SmbAbstraction.Tests.Integration
             FileSystem = new SMBFileSystem(SMBClientFactory, SMBCredentialProvider);
         }
 
-        public IFileSystem FileSystem { get; }
+        public TestFixture WithLoggerFactory(ILoggerFactory loggerFactory)
+        {
+            FileSystem = new SMBFileSystem(SMBClientFactory, SMBCredentialProvider, loggerFactory: loggerFactory);
+            return this;
+        }
+
+        public IFileSystem FileSystem { get; set; }
 
         public ISMBCredentialProvider SMBCredentialProvider { get; }
 

--- a/SmbAbstraction.Tests.Integration/SmbAbstraction.Tests.Integration.csproj
+++ b/SmbAbstraction.Tests.Integration/SmbAbstraction.Tests.Integration.csproj
@@ -9,9 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.1" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/SmbAbstraction.Tests/Client/SMBConnectionTests.cs
+++ b/SmbAbstraction.Tests/Client/SMBConnectionTests.cs
@@ -8,10 +8,6 @@ namespace SmbAbstraction.Tests.Path
 {
     public class SMBConnectionTests
     {
-        private readonly string domain = "domain";
-        private readonly string userName = "user";
-        private readonly string path = "\\\\host\\sharename";
-
         public SMBConnectionTests()
         {
         }
@@ -22,6 +18,7 @@ namespace SmbAbstraction.Tests.Path
             var domain = "domain";
             var userName = "user";
             var password = "password";
+            var path = "\\\\host\\sharename";
             var ipAddress = IPAddress.Parse("127.0.0.1");
 
             var credentials = new List<SMBCredential>() {

--- a/SmbAbstraction/Directory/SMBDirectory.cs
+++ b/SmbAbstraction/Directory/SMBDirectory.cs
@@ -686,6 +686,7 @@ namespace SmbAbstraction
             }
             catch (Exception ex)
             {
+                _logger?.LogTrace($"Failed to determine if {path} exists due to. {ex}");
                 return false;
             }
         }

--- a/SmbAbstraction/Directory/SMBDirectory.cs
+++ b/SmbAbstraction/Directory/SMBDirectory.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Security.AccessControl;
+using Microsoft.Extensions.Logging;
 using SMBLibrary;
 using SMBLibrary.Client;
 
@@ -11,6 +12,7 @@ namespace SmbAbstraction
 {
     public class SMBDirectory : DirectoryWrapper, IDirectory
     {
+        private readonly ILogger<SMBDirectory> _logger;
         private readonly ISMBClientFactory _smbClientFactory;
         private readonly IFileSystem _fileSystem;
         private readonly ISMBCredentialProvider _credentialProvider;
@@ -20,8 +22,9 @@ namespace SmbAbstraction
         public SMBTransportType transport { get; set; }
 
         public SMBDirectory(ISMBClientFactory smbclientFactory, ISMBCredentialProvider credentialProvider,
-            IFileSystem fileSystem, uint maxBufferSize) : base(new FileSystem())
+                    IFileSystem fileSystem, uint maxBufferSize, ILoggerFactory loggerFactory = null) : base(new FileSystem())
         {
+            _logger = loggerFactory?.CreateLogger<SMBDirectory>();
             _smbClientFactory = smbclientFactory;
             _credentialProvider = credentialProvider;
             _fileSystem = fileSystem;
@@ -43,7 +46,7 @@ namespace SmbAbstraction
 
             if (!path.TryResolveHostnameFromPath(out var ipAddress))
             {
-                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                throw new SMBException($"Failed to CreateDirectory {path}", new ArgumentException($"Unable to resolve \"{path.Hostname()}\""));
             }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
@@ -60,43 +63,59 @@ namespace SmbAbstraction
 
             if (credential == null)
             {
-                throw new Exception($"Unable to find credential for path: {path}");
+                throw new SMBException($"Failed to CreateDirectory {path}", new InvalidCredentialException($"Unable to find credential in SMBCredentialProvider for path: {path}"));
             }
 
-            using var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize);
-
-            var shareName = path.ShareName();
-            var relativePath = path.RelativeSharePath();
-
-            ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
-
-            status.HandleStatus();
-
-            int attempts = 0;
-            int allowedRetrys = 3;
-            object handle;
-
-            do
+            if(Exists(path))
             {
-                attempts++;
-
-                status = fileStore.CreateFile(out handle, out FileStatus fileStatus, relativePath, accessMask, 0, shareAccess,
-                disposition, createOptions, null);
-
-                if(status == NTStatus.STATUS_OBJECT_PATH_NOT_FOUND)
-                {
-                    CreateDirectory(path.GetParentPath(), credential);
-                    status = fileStore.CreateFile(out handle, out fileStatus, relativePath, accessMask, 0, shareAccess,
-                    disposition, createOptions, null);
-                }
+                return _directoryInfoFactory.FromDirectoryName(path);
             }
-            while (status == NTStatus.STATUS_PENDING && attempts < allowedRetrys);
 
-            status.HandleStatus();
+            try
+            {
+                var shareName = path.ShareName();
+                var relativePath = path.RelativeSharePath();
 
-            fileStore.CloseFile(handle);
+                _logger?.LogTrace($"Trying to CreateDirectory {{RelativePath: {relativePath}}} for {{ShareName: {shareName}}}");
 
-            return _directoryInfoFactory.FromDirectoryName(path, credential);
+                using var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize);
+
+                ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
+
+                status.HandleStatus();
+
+                int attempts = 0;
+                int allowedRetrys = 3;
+                object handle;
+
+                do
+                {
+                    attempts++;
+
+                    _logger?.LogTrace($"Attempt {attempts} to CreateDirectory {path}");
+
+                    status = fileStore.CreateFile(out handle, out FileStatus fileStatus, relativePath, accessMask, 0, shareAccess,
+                    disposition, createOptions, null);
+
+                    if (status == NTStatus.STATUS_OBJECT_PATH_NOT_FOUND)
+                    {
+                        CreateDirectory(path.GetParentPath(), credential);
+                        status = fileStore.CreateFile(out handle, out fileStatus, relativePath, accessMask, 0, shareAccess,
+                        disposition, createOptions, null);
+                    }
+                }
+                while (status == NTStatus.STATUS_PENDING && attempts < allowedRetrys);
+
+                status.HandleStatus();
+
+                fileStore.CloseFile(handle);
+
+                return _directoryInfoFactory.FromDirectoryName(path, credential);
+            }
+            catch(Exception ex)
+            {
+                throw new SMBException($"Failed to CreateDirectory {path}", ex);
+            }
         }
 
         public override void Delete(string path)
@@ -114,7 +133,12 @@ namespace SmbAbstraction
 
             if (!path.TryResolveHostnameFromPath(out var ipAddress))
             {
-                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                throw new SMBException($"Failed to Delete {path}", new ArgumentException($"Unable to resolve \"{path.Hostname()}\""));
+            }
+
+            if (!Exists(path))
+            {
+                return;
             }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
@@ -124,39 +148,55 @@ namespace SmbAbstraction
                 credential = _credentialProvider.GetSMBCredential(path);
             }
 
-            if (EnumerateFileSystemEntries(path).Count() > 0)
+            if (credential == null)
             {
-                throw new IOException("Cannot delete directory. Directory is not empty.");
+                throw new SMBException($"Failed to Delete {path}", new InvalidCredentialException($"Unable to find credential in SMBCredentialProvider for path: {path}"));
             }
 
-            using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
+            if (EnumerateFileSystemEntries(path).Count() > 0)
+            {
+                throw new SMBException($"Failed to Delete {path}", new IOException("Cannot delete directory. Directory is not empty."));
+            }
+
+            try
             {
                 var shareName = path.ShareName();
                 var relativePath = path.RelativeSharePath();
 
-                ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
+                _logger?.LogTrace($"Trying to Delete {{RelativePath: {relativePath}}} for {{ShareName: {shareName}}}");
 
-                status.HandleStatus();
-
-                int attempts = 0;
-                int allowedRetrys = 3;
-                object handle;
-
-                do
+                using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
                 {
-                    attempts++;
+                    ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
 
-                    status = fileStore.CreateFile(out handle, out FileStatus fileStatus, relativePath, AccessMask.DELETE, 0, ShareAccess.Delete,
-                    CreateDisposition.FILE_OPEN, CreateOptions.FILE_DELETE_ON_CLOSE, null);
+                    status.HandleStatus();
+
+                    int attempts = 0;
+                    int allowedRetrys = 3;
+                    object handle;
+
+                    do
+                    {
+                        attempts++;
+
+                        _logger?.LogTrace($"Attempt {attempts} to Delete {path}");
+
+                        status = fileStore.CreateFile(out handle, out FileStatus fileStatus, relativePath, AccessMask.DELETE, 0, ShareAccess.Delete,
+                        CreateDisposition.FILE_OPEN, CreateOptions.FILE_DELETE_ON_CLOSE, null);
+                    }
+                    while (status == NTStatus.STATUS_PENDING && attempts < allowedRetrys);
+
+                    status.HandleStatus();
+
+                    // This is the correct delete command, but it doesn't work for some reason. You have to use FILE_DELETE_ON_CLOSE
+                    // fileStore.SetFileInformation(handle, new FileDispositionInformation());
+
+                    fileStore.CloseFile(handle);
                 }
-                while (status == NTStatus.STATUS_PENDING && attempts < allowedRetrys);
-
-                status.HandleStatus();
-
-                // This is the correct delete command, but it doesn't work for some reason. You have to use FILE_DELETE_ON_CLOSE
-                // fileStore.SetFileInformation(handle, new FileDispositionInformation());
-
-                fileStore.CloseFile(handle);
+            }
+            catch(Exception ex)
+            {
+                throw new SMBException($"Failed to Delete {path}", ex);
             }
         }
 
@@ -177,7 +217,7 @@ namespace SmbAbstraction
             {
                 if (!path.TryResolveHostnameFromPath(out var ipAddress))
                 {
-                    throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                    throw new SMBException($"Failed to Delete {path}", new ArgumentException($"Unable to resolve \"{path.Hostname()}\""));
                 }
 
                 NTStatus status = NTStatus.STATUS_SUCCESS;
@@ -187,54 +227,70 @@ namespace SmbAbstraction
                     credential = _credentialProvider.GetSMBCredential(path);
                 }
 
-                using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
+                if (credential == null)
+                {
+                    throw new SMBException($"Failed to Delete {path}", new InvalidCredentialException("Unable to find credential in SMBCredentialProvider for path: {path}"));
+                }
+
+                try
                 {
                     var shareName = path.ShareName();
                     var relativePath = path.RelativeSharePath();
 
-                    ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
+                    _logger?.LogTrace($"Trying to Delete {{RelativePath: {relativePath}}} for {{ShareName: {shareName}}}");
 
-                    status.HandleStatus();
-
-                    int attempts = 0;
-                    int allowedRetrys = 3;
-                    object handle;
-
-                    do
+                    using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
                     {
-                        attempts++;
+                        ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
 
-                        status = fileStore.CreateFile(out handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Delete,
-                            CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
-                    }
-                    while (status == NTStatus.STATUS_PENDING && attempts < allowedRetrys);
+                        status.HandleStatus();
 
-                    status.HandleStatus();
+                        int attempts = 0;
+                        int allowedRetrys = 3;
+                        object handle;
 
-                    fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, "*", FileInformationClass.FileDirectoryInformation);
-
-                    foreach (var file in queryDirectoryFileInformation)
-                    {
-                        if (file.FileInformationClass == FileInformationClass.FileDirectoryInformation)
+                        do
                         {
-                            FileDirectoryInformation fileDirectoryInformation = (FileDirectoryInformation)file;
-                            if (fileDirectoryInformation.FileName == "."
-                                || fileDirectoryInformation.FileName == ".."
-                                || fileDirectoryInformation.FileName == ".DS_Store")
-                            {
-                                continue;
-                            }
-                            else if (fileDirectoryInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
-                            {
-                                Delete(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName), recursive, credential);
-                            }
+                            attempts++;
 
-                            _fileSystem.File.Delete(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName));
+                            _logger?.LogTrace($"Attempt {attempts} to Delete {path}");
+
+                            status = fileStore.CreateFile(out handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Delete,
+                                CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
                         }
-                    }
-                    fileStore.CloseFile(handle);
+                        while (status == NTStatus.STATUS_PENDING && attempts < allowedRetrys);
 
-                    Delete(path, credential);
+                        status.HandleStatus();
+
+                        fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, "*", FileInformationClass.FileDirectoryInformation);
+
+                        foreach (var file in queryDirectoryFileInformation)
+                        {
+                            if (file.FileInformationClass == FileInformationClass.FileDirectoryInformation)
+                            {
+                                FileDirectoryInformation fileDirectoryInformation = (FileDirectoryInformation)file;
+                                if (fileDirectoryInformation.FileName == "."
+                                    || fileDirectoryInformation.FileName == ".."
+                                    || fileDirectoryInformation.FileName == ".DS_Store")
+                                {
+                                    continue;
+                                }
+                                else if (fileDirectoryInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
+                                {
+                                    Delete(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName), recursive, credential);
+                                }
+
+                                _fileSystem.File.Delete(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName));
+                            }
+                        }
+                        fileStore.CloseFile(handle);
+
+                        Delete(path, credential);
+                    }
+                }
+                catch(Exception ex)
+                {
+                    throw new SMBException($"Failed to Delete {path}", ex);
                 }
             }
             else
@@ -277,7 +333,7 @@ namespace SmbAbstraction
 
             if (!path.TryResolveHostnameFromPath(out var ipAddress))
             {
-                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                throw new SMBException($"Failed to EnumerateDirectories for {path}", new ArgumentException($"Unable to resolve \"{path.Hostname()}\""));
             }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
@@ -287,49 +343,65 @@ namespace SmbAbstraction
                 credential = _credentialProvider.GetSMBCredential(path);
             }
 
-            using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
+            if (credential == null)
+            {
+                throw new SMBException($"Failed to EnumerateDirectories for {path}", new InvalidCredentialException($"Unable to find credential in SMBCredentialProvider for path: {path}"));
+            }
+
+            try
             {
                 var shareName = path.ShareName();
                 var relativePath = path.RelativeSharePath();
 
-                ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
+                _logger?.LogTrace($"Trying to EnumerateDirectories {{RelativePath: {relativePath}}} for {{ShareName: {shareName}}}");
 
-                status.HandleStatus();
-
-                status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
-                    CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
-
-                status.HandleStatus();
-
-                fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
-
-
-                List<string> files = new List<string>();
-
-                foreach (var file in queryDirectoryFileInformation)
+                using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
                 {
-                    if (file.FileInformationClass == FileInformationClass.FileDirectoryInformation)
+
+                    ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
+
+                    status.HandleStatus();
+
+                    status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
+                        CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
+
+                    status.HandleStatus();
+
+                    fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
+
+                    _logger?.LogTrace($"Found {queryDirectoryFileInformation.Count} FileDirectoryInformation for {path}");
+
+                    List<string> files = new List<string>();
+
+                    foreach (var file in queryDirectoryFileInformation)
                     {
-                        FileDirectoryInformation fileDirectoryInformation = (FileDirectoryInformation)file;
-
-                        if (fileDirectoryInformation.FileName == "." || fileDirectoryInformation.FileName == "..")
+                        if (file.FileInformationClass == FileInformationClass.FileDirectoryInformation)
                         {
-                            continue;
-                        }
+                            FileDirectoryInformation fileDirectoryInformation = (FileDirectoryInformation)file;
 
-                        if (fileDirectoryInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
-                        {
-                            files.Add(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName));
-                            if (searchOption == SearchOption.AllDirectories)
+                            if (fileDirectoryInformation.FileName == "." || fileDirectoryInformation.FileName == "..")
                             {
-                                files.AddRange(EnumerateDirectories(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName), searchPattern, searchOption, credential));
+                                continue;
+                            }
+
+                            if (fileDirectoryInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
+                            {
+                                files.Add(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName));
+                                if (searchOption == SearchOption.AllDirectories)
+                                {
+                                    files.AddRange(EnumerateDirectories(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName), searchPattern, searchOption, credential));
+                                }
                             }
                         }
                     }
-                }
-                fileStore.CloseFile(handle);
+                    fileStore.CloseFile(handle);
 
-                return files;
+                    return files;
+                }
+            }
+            catch(Exception ex)
+            {
+                throw new SMBException($"Failed to EnumerateDirectories for {path}", ex);
             }
         }
 
@@ -367,7 +439,7 @@ namespace SmbAbstraction
 
             if (!path.TryResolveHostnameFromPath(out var ipAddress))
             {
-                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                throw new SMBException($"Failed to EnumerateFiles for {path}", new ArgumentException($"Unable to resolve \"{path.Hostname()}\""));
             }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
@@ -377,53 +449,68 @@ namespace SmbAbstraction
                 credential = _credentialProvider.GetSMBCredential(path);
             }
 
-            using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
+            if (credential == null)
+            {
+                throw new SMBException($"Failed to EnumerateFiles for {path}", new InvalidCredentialException($"Unable to find credential in SMBCredentialProvider for path: {path}"));
+            }
+
+            try
             {
                 var shareName = path.ShareName();
                 var relativePath = path.RelativeSharePath();
 
-                ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
+                _logger?.LogTrace($"Trying to EnumerateFiles for {{RelativePath: {relativePath}}} for {{ShareName: {shareName}}}");
 
-                status.HandleStatus();
-
-                status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
-                    CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
-
-                status.HandleStatus();
-
-                fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
-
-
-                List<string> files = new List<string>();
-
-                foreach (var file in queryDirectoryFileInformation)
+                using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
                 {
-                    if (file.FileInformationClass == FileInformationClass.FileDirectoryInformation)
-                    {
-                        FileDirectoryInformation fileDirectoryInformation = (FileDirectoryInformation)file;
-                        if (fileDirectoryInformation.FileName == "."
-                            || fileDirectoryInformation.FileName == ".."
-                            || fileDirectoryInformation.FileName == ".DS_Store")
-                        {
-                            continue;
-                        }
+                    ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
 
-                        if (fileDirectoryInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
+                    status.HandleStatus();
+
+                    status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
+                        CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
+
+                    status.HandleStatus();
+
+                    fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
+
+                    _logger?.LogTrace($"Found {queryDirectoryFileInformation.Count} FileDirectoryInformation for {path}");
+
+                    List<string> files = new List<string>();
+
+                    foreach (var file in queryDirectoryFileInformation)
+                    {
+                        if (file.FileInformationClass == FileInformationClass.FileDirectoryInformation)
                         {
-                            if (searchOption == SearchOption.AllDirectories)
+                            FileDirectoryInformation fileDirectoryInformation = (FileDirectoryInformation)file;
+                            if (fileDirectoryInformation.FileName == "."
+                                || fileDirectoryInformation.FileName == ".."
+                                || fileDirectoryInformation.FileName == ".DS_Store")
                             {
-                                files.AddRange(EnumerateFiles(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName), searchPattern, searchOption, credential));
+                                continue;
+                            }
+
+                            if (fileDirectoryInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
+                            {
+                                if (searchOption == SearchOption.AllDirectories)
+                                {
+                                    files.AddRange(EnumerateFiles(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName), searchPattern, searchOption, credential));
+                                }
+                            }
+                            else
+                            {
+                                files.Add(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName.RemoveAnySeperators()));
                             }
                         }
-                        else
-                        {
-                            files.Add(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName.RemoveAnySeperators()));
-                        }
                     }
-                }
-                fileStore.CloseFile(handle);
+                    fileStore.CloseFile(handle);
 
-                return files;
+                    return files;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new SMBException($"Failed to EnumerateFiles {path}", ex);
             }
         }
 
@@ -462,7 +549,7 @@ namespace SmbAbstraction
 
             if (!path.TryResolveHostnameFromPath(out var ipAddress))
             {
-                throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                throw new SMBException($"Failed to EnumerateFileSystemEntries for {path}", new ArgumentException($"Unable to resolve \"{path.Hostname()}\""));
             }
 
             NTStatus status = NTStatus.STATUS_SUCCESS;
@@ -472,50 +559,65 @@ namespace SmbAbstraction
                 credential = _credentialProvider.GetSMBCredential(path);
             }
 
-            using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
+            if (credential == null)
+            {
+                throw new SMBException($"Failed to EnumerateFileSystemEntries for {path}", new InvalidCredentialException($"Unable to find credential in SMBCredentialProvider for path: {path}"));
+            }
+
+            try
             {
                 var shareName = path.ShareName();
                 var relativePath = path.RelativeSharePath();
 
-                ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
+                _logger?.LogTrace($"Trying to EnumerateFileSystemEntries {{RelativePath: {relativePath}}} for {{ShareName: {shareName}}}");
 
-                status.HandleStatus();
-
-                status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
-                    CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
-
-                status.HandleStatus();
-
-                fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
-
-
-                List<string> files = new List<string>();
-
-                foreach (var file in queryDirectoryFileInformation)
+                using (var connection = SMBConnection.CreateSMBConnection(_smbClientFactory, ipAddress, transport, credential, _maxBufferSize))
                 {
-                    if (file.FileInformationClass == FileInformationClass.FileDirectoryInformation)
+                    ISMBFileStore fileStore = connection.SMBClient.TreeConnect(shareName, out status);
+
+                    status.HandleStatus();
+
+                    status = fileStore.CreateFile(out object handle, out FileStatus fileStatus, relativePath, AccessMask.GENERIC_READ, 0, ShareAccess.Read,
+                        CreateDisposition.FILE_OPEN, CreateOptions.FILE_DIRECTORY_FILE, null);
+
+                    status.HandleStatus();
+
+                    fileStore.QueryDirectory(out List<QueryDirectoryFileInformation> queryDirectoryFileInformation, handle, searchPattern, FileInformationClass.FileDirectoryInformation);
+
+                    _logger?.LogTrace($"Found {queryDirectoryFileInformation.Count} FileDirectoryInformation for {path}");
+
+                    List<string> files = new List<string>();
+
+                    foreach (var file in queryDirectoryFileInformation)
                     {
-                        FileDirectoryInformation fileDirectoryInformation = (FileDirectoryInformation)file;
-                        if (fileDirectoryInformation.FileName == "." || fileDirectoryInformation.FileName == ".." || fileDirectoryInformation.FileName == ".DS_Store")
+                        if (file.FileInformationClass == FileInformationClass.FileDirectoryInformation)
                         {
-                            continue;
-                        }
-
-
-                        if (fileDirectoryInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
-                        {
-                            if (searchOption == SearchOption.AllDirectories)
+                            FileDirectoryInformation fileDirectoryInformation = (FileDirectoryInformation)file;
+                            if (fileDirectoryInformation.FileName == "." || fileDirectoryInformation.FileName == ".." || fileDirectoryInformation.FileName == ".DS_Store")
                             {
-                                files.AddRange(EnumerateFileSystemEntries(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName), searchPattern, searchOption, credential));
+                                continue;
                             }
+
+
+                            if (fileDirectoryInformation.FileAttributes.HasFlag(SMBLibrary.FileAttributes.Directory))
+                            {
+                                if (searchOption == SearchOption.AllDirectories)
+                                {
+                                    files.AddRange(EnumerateFileSystemEntries(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName), searchPattern, searchOption, credential));
+                                }
+                            }
+
+                            files.Add(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName));
                         }
-
-                        files.Add(_fileSystem.Path.Combine(path, fileDirectoryInformation.FileName));
                     }
-                }
-                fileStore.CloseFile(handle);
+                    fileStore.CloseFile(handle);
 
-                return files;
+                    return files;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new SMBException($"Failed to EnumerateFileSystemEntries for {path}", ex);
             }
         }
 
@@ -530,7 +632,7 @@ namespace SmbAbstraction
             {
                 if (!path.TryResolveHostnameFromPath(out var ipAddress))
                 {
-                    throw new ArgumentException($"Unable to resolve \"{path.Hostname()}\"");
+                    throw new SMBException($"Failed to determine if {path} exists", new ArgumentException($"Unable to resolve \"{path.Hostname()}\""));
                 }
 
                 NTStatus status = NTStatus.STATUS_SUCCESS;
@@ -542,7 +644,9 @@ namespace SmbAbstraction
                     var shareName = path.ShareName();
                     var relativePath = path.RelativeSharePath();
 
-                    if(string.IsNullOrEmpty(relativePath))
+                    _logger?.LogTrace($"Trying to determine if {{RelativePath: {relativePath}}} Exists for {{ShareName: {shareName}}}");
+
+                    if (string.IsNullOrEmpty(relativePath))
                     {
                         return true;
                     }
@@ -580,7 +684,7 @@ namespace SmbAbstraction
 
                 return false;
             }
-            catch
+            catch (Exception ex)
             {
                 return false;
             }
@@ -628,7 +732,7 @@ namespace SmbAbstraction
 
         public override string GetCurrentDirectory()
         {
-            throw new NotImplementedException();
+            return base.GetCurrentDirectory();
         }
 
         public override string[] GetDirectories(string path)

--- a/SmbAbstraction/Directory/SMBDirectory.cs
+++ b/SmbAbstraction/Directory/SMBDirectory.cs
@@ -686,7 +686,7 @@ namespace SmbAbstraction
             }
             catch (Exception ex)
             {
-                _logger?.LogTrace($"Failed to determine if {path} exists due to. {ex}");
+                _logger?.LogTrace(ex, $"Failed to determine if {path} exists.");
                 return false;
             }
         }

--- a/SmbAbstraction/Directory/SMBDirectoryInfoFactory.cs
+++ b/SmbAbstraction/Directory/SMBDirectoryInfoFactory.cs
@@ -9,7 +9,6 @@ namespace SmbAbstraction
 {
     public class SMBDirectoryInfoFactory : IDirectoryInfoFactory
     {
-        private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<SMBDirectoryInfoFactory> _logger;
         private readonly IFileSystem _fileSystem;
         private readonly ISMBCredentialProvider _credentialProvider;
@@ -24,8 +23,7 @@ namespace SmbAbstraction
         public SMBDirectoryInfoFactory(IFileSystem fileSystem, ISMBCredentialProvider credentialProvider,
             ISMBClientFactory smbClientFactory, uint maxBufferSize, ILoggerFactory loggerFactory = null)
         {
-            _loggerFactory = loggerFactory;
-            _logger = _loggerFactory?.CreateLogger<SMBDirectoryInfoFactory>();
+            _logger = loggerFactory?.CreateLogger<SMBDirectoryInfoFactory>();
             _fileSystem = fileSystem;
             _credentialProvider = credentialProvider;
             _smbClientFactory = smbClientFactory;

--- a/SmbAbstraction/Exception/SMBException.cs
+++ b/SmbAbstraction/Exception/SMBException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SmbAbstraction
+{
+    public class SMBException : Exception
+    {
+        public SMBException(string message) : base(message)
+        { 
+        }
+
+        public SMBException(string message, Exception exception): base(message, exception)
+        {
+        }
+    }
+}

--- a/SmbAbstraction/Exception/SmbException.cs
+++ b/SmbAbstraction/Exception/SmbException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SmbAbstraction
+{
+    public class SMBException : Exception
+    {
+        public SMBException(string message) : base(message)
+        { 
+        }
+
+        public SMBException(string message, Exception exception): base(message, exception)
+        {
+        }
+    }
+}

--- a/SmbAbstraction/File/SMBFile.cs
+++ b/SmbAbstraction/File/SMBFile.cs
@@ -340,6 +340,7 @@ namespace SmbAbstraction
             }
             catch (Exception ex)
             {
+                _logger?.LogTrace($"Failed to determine if {path} exists due to. {ex}");
                 return false;
             }
         }

--- a/SmbAbstraction/File/SMBFile.cs
+++ b/SmbAbstraction/File/SMBFile.cs
@@ -340,7 +340,7 @@ namespace SmbAbstraction
             }
             catch (Exception ex)
             {
-                _logger?.LogTrace($"Failed to determine if {path} exists due to. {ex}");
+                _logger?.LogTrace(ex, $"Failed to determine if {path} exists.");
                 return false;
             }
         }

--- a/SmbAbstraction/FileSystem/SMBFileSystem.cs
+++ b/SmbAbstraction/FileSystem/SMBFileSystem.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
 using SMBLibrary.Client;
 
 namespace SmbAbstraction
 {
     public class SMBFileSystem : IFileSystem
     {
-        public SMBFileSystem(ISMBClientFactory ismbClientfactory, ISMBCredentialProvider credentialProvider, uint maxBufferSize = 65536)
+        public SMBFileSystem(ISMBClientFactory ismbClientfactory, ISMBCredentialProvider credentialProvider, uint maxBufferSize = 65536, ILoggerFactory loggerFactory = null)
         {
             File = new SMBFile(ismbClientfactory, credentialProvider, this, maxBufferSize);
-            Directory = new SMBDirectory(ismbClientfactory, credentialProvider, this, maxBufferSize);
+            Directory = new SMBDirectory(ismbClientfactory, credentialProvider, this, maxBufferSize, loggerFactory);
             DirectoryInfo = new SMBDirectoryInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);
             FileInfo = new SMBFileInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);
             FileStream = new SMBFileStreamFactory(this);

--- a/SmbAbstraction/FileSystem/SMBFileSystem.cs
+++ b/SmbAbstraction/FileSystem/SMBFileSystem.cs
@@ -15,7 +15,7 @@ namespace SmbAbstraction
             FileInfo = new SMBFileInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize, loggerFactory);
             FileStream = new SMBFileStreamFactory(this);
             Path = new SMBPath(this);
-            DriveInfo = new SMBDriveInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);
+            DriveInfo = new SMBDriveInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize, loggerFactory);
         }
 
         public IDirectory Directory { get; }

--- a/SmbAbstraction/FileSystem/SMBFileSystem.cs
+++ b/SmbAbstraction/FileSystem/SMBFileSystem.cs
@@ -9,7 +9,7 @@ namespace SmbAbstraction
     {
         public SMBFileSystem(ISMBClientFactory ismbClientfactory, ISMBCredentialProvider credentialProvider, uint maxBufferSize = 65536, ILoggerFactory loggerFactory = null)
         {
-            File = new SMBFile(ismbClientfactory, credentialProvider, this, maxBufferSize);
+            File = new SMBFile(ismbClientfactory, credentialProvider, this, maxBufferSize, loggerFactory);
             Directory = new SMBDirectory(ismbClientfactory, credentialProvider, this, maxBufferSize, loggerFactory);
             DirectoryInfo = new SMBDirectoryInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);
             FileInfo = new SMBFileInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);

--- a/SmbAbstraction/FileSystem/SMBFileSystem.cs
+++ b/SmbAbstraction/FileSystem/SMBFileSystem.cs
@@ -11,7 +11,7 @@ namespace SmbAbstraction
         {
             File = new SMBFile(ismbClientfactory, credentialProvider, this, maxBufferSize, loggerFactory);
             Directory = new SMBDirectory(ismbClientfactory, credentialProvider, this, maxBufferSize, loggerFactory);
-            DirectoryInfo = new SMBDirectoryInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);
+            DirectoryInfo = new SMBDirectoryInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize, loggerFactory);
             FileInfo = new SMBFileInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);
             FileStream = new SMBFileStreamFactory(this);
             Path = new SMBPath(this);

--- a/SmbAbstraction/FileSystem/SMBFileSystem.cs
+++ b/SmbAbstraction/FileSystem/SMBFileSystem.cs
@@ -12,7 +12,7 @@ namespace SmbAbstraction
             File = new SMBFile(ismbClientfactory, credentialProvider, this, maxBufferSize, loggerFactory);
             Directory = new SMBDirectory(ismbClientfactory, credentialProvider, this, maxBufferSize, loggerFactory);
             DirectoryInfo = new SMBDirectoryInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize, loggerFactory);
-            FileInfo = new SMBFileInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);
+            FileInfo = new SMBFileInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize, loggerFactory);
             FileStream = new SMBFileStreamFactory(this);
             Path = new SMBPath(this);
             DriveInfo = new SMBDriveInfoFactory(this, credentialProvider, ismbClientfactory, maxBufferSize);

--- a/SmbAbstraction/SmbAbstraction.csproj
+++ b/SmbAbstraction/SmbAbstraction.csproj
@@ -29,6 +29,7 @@
     <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
     <PackageReference Include="System.IO.Abstractions" Version="10.0.1" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Add an optional `ILoggerFactory` to 
- `SMBFile`
- `SMBDirectory`
- `SMBDirectoryInfoFactory`
- `SMBFileInfoFactory`
- `SMBDriveInfoFactory`

so that consumers of the library are able to see `Trace` log outputs of operations that happen in `SMBFileSystem`

Update tests so that they utilize `ITestOutputHelper` and we can view the log outputs of each test.

Add `SMBException`, add try catches to operations, and wrap existing `Exceptions` 